### PR TITLE
Portfolio Handle Multiple Completions

### DIFF
--- a/type/Portfolio/portfolio_data.php
+++ b/type/Portfolio/portfolio_data.php
@@ -63,26 +63,26 @@ class portfolio_data {
         $course_sql = "
             SELECT  c.fullname,
                     max(cc.timecompleted) as timecompleted
-            FROM {course} c
-                INNER JOIN {customfield_data} cd ON
-                    cd.instanceid = c.id AND
-                    cd.intvalue = 1 AND
-                    cd.fieldid = ? 
-                INNER JOIN (
-                    (
-                        SELECT *
-                        FROM {course_completions} ccc 
-                        WHERE ccc.userid = ?
-                    ) UNION
-                    (
-                        SELECT *
-                        FROM {local_recompletion_cc} rcc
-                        WHERE rcc.userid = ?
-                    )
-                ) cc ON
-                    cc.course = c.id AND
-                    cc.userid = ? AND 
-                    cc.timecompleted IS NOT NULL
+            FROM    {course} c
+                    INNER JOIN {customfield_data} cd ON
+                        cd.instanceid = c.id AND
+                        cd.intvalue = 1 AND
+                        cd.fieldid = ? 
+                    INNER JOIN (
+                        (
+                            SELECT  *
+                            FROM    {course_completions} ccc 
+                            WHERE   ccc.userid = ?
+                        ) UNION
+                        (
+                            SELECT  *
+                            FROM    {local_recompletion_cc} rcc
+                            WHERE   rcc.userid = ?
+                        )
+                    ) cc ON
+                        cc.course = c.id AND
+                        cc.userid = ? AND 
+                        cc.timecompleted IS NOT NULL
             GROUP BY c.id
             ORDER BY c.fullname
         ";

--- a/type/Portfolio/portfolio_data.php
+++ b/type/Portfolio/portfolio_data.php
@@ -83,6 +83,7 @@ class portfolio_data {
                     cc.course = c.id AND
                     cc.userid = ? AND 
                     cc.timecompleted IS NOT NULL
+            GROUP BY c.id
             ORDER BY c.fullname
         ";
 

--- a/type/Portfolio/portfolio_data.php
+++ b/type/Portfolio/portfolio_data.php
@@ -62,7 +62,7 @@ class portfolio_data {
 
         $course_sql = "
             SELECT  c.fullname,
-                    cc.timecompleted 
+                    max(cc.timecompleted) as timecompleted
             FROM {course} c
                 INNER JOIN {customfield_data} cd ON
                     cd.instanceid = c.id AND


### PR DESCRIPTION
Updates the `portfolio_data` class to better handle courses with multiple course completion / recompletion records.
This is achieved with:
1. Group query results by course ID to prevent multiple results for the same course.
2. Use `max()` to get the most recent course completion.