### PR TITLE
Backport Repository Certificate Changes

### DIFF
--- a/lang/en/certificate.php
+++ b/lang/en/certificate.php
@@ -213,6 +213,10 @@ $string['viewed'] = 'You received this certificate on:';
 $string['viewtranscript'] = 'View Certificates';
 $string['watermark'] = 'Watermark';
 
+// Settings
+$string['setting:reponame'] = 'Certificate Type Repository Name';
+$string['setting:reponame_desc'] = 'Name of the repository to load certificate types from instead of the internal types directory.';
+
 $string['privacy:metadata:mod_certificate'] = 'Info about issued certificates';
 $string['privacy:metadata:mod_certificate:userid'] = 'User info';
 $string['privacy:metadata:mod_certificate:certificateid'] = 'Certificate info';

--- a/locallib.php
+++ b/locallib.php
@@ -788,7 +788,7 @@ function certificate_get_directories(string $types_directory): array {
     $types = [];
     while (($directory = readdir($handle)) !== false) {
         if (
-            str_starts_with($directory, '.') ||
+            strpos($directory, '.') === 0 ||
             !is_dir("$types_directory/$directory")
         ) {
             continue;

--- a/settings.php
+++ b/settings.php
@@ -36,4 +36,11 @@ if ($ADMIN->fulltree) {
     $settings->add(new mod_certificate_admin_setting_font('certificate/fontserif',
         get_string('fontserif', 'mod_certificate'), get_string('fontserif_desc', 'mod_certificate'), 'freeserif'));
 
+    $settings->add(new admin_setting_configtext(
+        'certificate/reponame',
+        get_string('setting:reponame', 'mod_certificate'),
+        get_string('setting:reponame_desc', 'mod_certificate'),
+        '',
+        PARAM_TEXT
+    ));
 }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023061400; // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2023061500; // The current module version (Date: YYYYMMDDXX)
 $plugin->requires  = 2016052300; // Requires this Moodle version (3.1)
 $plugin->cron      = 0; // Period for cron to check this module (secs)
 $plugin->component = 'mod_certificate';

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020082500; // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2023061400; // The current module version (Date: YYYYMMDDXX)
 $plugin->requires  = 2016052300; // Requires this Moodle version (3.1)
 $plugin->cron      = 0; // Period for cron to check this module (secs)
 $plugin->component = 'mod_certificate';

--- a/view.php
+++ b/view.php
@@ -92,7 +92,12 @@ $certrecord = certificate_get_issue($course, $USER, $certificate, $cm);
 make_cache_directory('tcpdf');
 
 // Load the specific certificate type.
-require("$CFG->dirroot/mod/certificate/type/$certificate->certificatetype/certificate.php");
+$require_path = "$CFG->dirroot/mod/certificate/type/$certificate->certificatetype/certificate.php";
+$repo_name = get_config('certificate', 'reponame');
+if (!empty($repo_name)) {
+    $require_path = "$CFG->dataroot/repository/$repo_name/CERTIFICATE/type/$certificate->certificatetype/certificate.php";
+}
+require($require_path);
 
 if (empty($action)) { // Not displaying PDF
     echo $OUTPUT->header();


### PR DESCRIPTION
Backport the changes to support certificates from the repository as made in #3 with PHP 7 compatibility tweaks.