### PR TITLE
GS-484 Going for Gold Certificate Unnecessary Appendix

### DIFF
--- a/type/GFG/certificate.php
+++ b/type/GFG/certificate.php
@@ -390,7 +390,10 @@ function is_long_content(TCPDF $pdf, string $content): bool {
         return true;
     }
 
-    $content_lines = $pdf->getNumLines($trimmed_content, 200);
+    $content_lines = $pdf->getNumLines(
+        $trimmed_content,
+        $pdf->getPageWidth()
+    );
     if ($content_lines > 3) {
         return true;
     }


### PR DESCRIPTION
Use the actual PDF page width instead of static value when calculating number of lines for long content.
Fixes the creation of unnecessary appendix pages for medium length single paragraph content.