### PR TITLE
GS-386 Change date format default setting

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -92,7 +92,7 @@ class mod_certificate_mod_form extends moodleform_mod {
         $dateformatoptions = array( 1 => 'January 1, 2000', 2 => 'January 1st, 2000', 3 => '1 January 2000',
             4 => 'January 2000', 5 => get_string('userdateformat', 'certificate'));
         $mform->addElement('select', 'datefmt', get_string('datefmt', 'certificate'), $dateformatoptions);
-        $mform->setDefault('datefmt', 0);
+        $mform->setDefault('datefmt', 5);
         $mform->addHelpButton('datefmt', 'datefmt', 'certificate');
 
         $mform->addElement('select', 'printnumber', get_string('printnumber', 'certificate'), $ynoptions);

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023061510; // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2023061500; // The current module version (Date: YYYYMMDDXX)
 $plugin->requires  = 2016052300; // Requires this Moodle version (3.1)
 $plugin->cron      = 0; // Period for cron to check this module (secs)
 $plugin->component = 'mod_certificate';

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023061500; // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2023061510; // The current module version (Date: YYYYMMDDXX)
 $plugin->requires  = 2016052300; // Requires this Moodle version (3.1)
 $plugin->cron      = 0; // Period for cron to check this module (secs)
 $plugin->component = 'mod_certificate';


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
Issue: Courses builders are requesting to change the default to Australian standard format.

This PR solves this by changing the default time format when adding a certificate. It should show up as users default date which equate to DD/MM/YYYY

<img width="970" height="346" alt="image" src="https://github.com/user-attachments/assets/7c8bd4c4-1c8d-44ab-87c1-1e1182a138bb" />


## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).

